### PR TITLE
chore: add renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
     "extends": [
-        "config:base"
+        "config:base",        
     ],
     "semanticCommitType": "chore",
     "semanticCommitScope": "deps",
@@ -8,6 +8,7 @@
     "prCreation": "immediate",
     "pruneStaleBranches": true,
     "unicodeEmoji": true,
+    "automergeStrategy": "squash",
     "postUpdateOptions": [
         "gomodTidy",
         "gomodUpdateImportPaths"
@@ -18,13 +19,15 @@
     },
     "packageRules": [
         {
-            "matchPackagePatterns": [
-                "mage"
+            "matchPackageNames": [
+                "github.com/magefile/mage"
             ],
             "matchLanguages": [
                 "golang"
             ],
-            "groupName": "go-dev-tooling-autoapprove"
+            "groupName": "mage-auto-approve",
+            "automergeType": "pr",
+            "patch": true
         }
     ],
     "vulnerabilityAlerts": {

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,36 @@
+{
+    "extends": [
+        "config:base"
+    ],
+    "semanticCommitType": "chore",
+    "semanticCommitScope": "deps",
+    "rebaseWhen": "behind-base-branch",
+    "prCreation": "immediate",
+    "pruneStaleBranches": true,
+    "unicodeEmoji": true,
+    "postUpdateOptions": [
+        "gomodTidy",
+        "gomodUpdateImportPaths"
+    ],
+    "gomod": {
+        "enabled": true,
+        "commitMessageTopic": "⬆️ go module {{depName}}"
+    },
+    "packageRules": [
+        {
+            "matchPackagePatterns": [
+                "mage"
+            ],
+            "matchLanguages": [
+                "golang"
+            ],
+            "groupName": "go-dev-tooling-autoapprove"
+        }
+    ],
+    "vulnerabilityAlerts": {
+        "enabled": true,
+        "labels": [
+            "security"
+        ]
+    }
+}


### PR DESCRIPTION
- Include renovate configuration.
- Include automerge of PR upon matching mage based package name. (IE this will automatically approve and merge PR).

This doesn't handle automatically tagging a new release, but dependencies will be updated.
To automate the tagging based on merge I have other tools for this I can recommend or use a prebuilt github action.

You should add the Renovate Github app for this to work BTW. I recommend installing on your user org and just add a renovate.json to any repos you want to enable it on. It's like dependabot and should make life a lot easier. 

Docs are located here: [whitesource renovate docs](https://docs.renovatebot.com/configuration-options/)

- Related to work on #5 