### PR TITLE
Gracefully handle magefiles with Default set

### DIFF
--- a/main.go
+++ b/main.go
@@ -62,8 +62,10 @@ func main() {
 		line := scan.Text()
 		if strings.HasPrefix(line, "Targets:") {
 			continue
+		} else if strings.TrimSpace(line) == "" {
+			break
 		}
-		line = strings.TrimSpace(line)
+		line = strings.TrimSpace(strings.ReplaceAll(line, "*", ""))
 		targets = append(targets, line)
 	}
 


### PR DESCRIPTION
- break on empty line, separating targets from "* default target" notice
- trim * suffix from default target

Fixes #15. 